### PR TITLE
Fix pseudonimization config

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -54,9 +54,9 @@ class ConfigProvider
                             'gr2o_email' => [
                                 'email' => [
                                     '{gr2o_patient_nr}',
-                                    '@',
+                                    '@org',
                                     '{gr2o_id_organization}',
-                                    '@example.test',
+                                    'example.test',
                                 ],
                             ],
                         ],


### PR DESCRIPTION
We now get an email address like 123456@org88example.test instead of an invalid email address 123456@88@example.test.